### PR TITLE
delete developer outputs and replace default jobId with None

### DIFF
--- a/Part-II/05_amazon_cloud_access/tutorial7-zarr.ipynb
+++ b/Part-II/05_amazon_cloud_access/tutorial7-zarr.ipynb
@@ -135,22 +135,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 31,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2020-11-20T21:41:57.314395Z",
      "start_time": "2020-11-20T21:41:52.177000Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "# Your URS credentials were securely retrieved from your .netrc file.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from platform import system\n",
     "from netrc import netrc\n",
@@ -506,8 +498,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#async_jobId = None  \n",
-    "async_jobId = \"dfefc536-768c-4db3-a7d2-c326e9253042\""
+    "#async_jobId = \"dfefc536-768c-4db3-a7d2-c326e9253042\"  # jobId belongs to dev. You wont have access.\n",
+    "async_jobId = None "
    ]
   },
   {
@@ -551,7 +543,33 @@
    "cell_type": "code",
    "execution_count": 14,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Request URL:  https://harmony.earthdata.nasa.gov/C1938032626-POCLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?format=application/x-zarr\n",
+      "{\n",
+      "  \"username\": \"jmcnelis\",\n",
+      "  \"status\": \"running\",\n",
+      "  \"message\": \"The job is being processed\",\n",
+      "  \"progress\": 0,\n",
+      "  \"createdAt\": \"2020-12-02T22:22:56.588Z\",\n",
+      "  \"updatedAt\": \"2020-12-02T22:22:56.588Z\",\n",
+      "  \"links\": [\n",
+      "    {\n",
+      "      \"title\": \"Job Status\",\n",
+      "      \"href\": \"https://harmony.earthdata.nasa.gov/jobs/89d0a34f-d9bd-466e-bd7b-f93891956b7b\",\n",
+      "      \"rel\": \"self\",\n",
+      "      \"type\": \"application/json\"\n",
+      "    }\n",
+      "  ],\n",
+      "  \"request\": \"https://harmony.earthdata.nasa.gov/C1938032626-POCLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?format=application%2Fx-zarr\",\n",
+      "  \"jobID\": \"89d0a34f-d9bd-466e-bd7b-f93891956b7b\"\n",
+      "}\n"
+     ]
+    }
+   ],
    "source": [
     "async_url = f'https://{harmony}/{collection_concept_id}/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?format=application/x-zarr'\n",
     "if async_jobId is None:\n",
@@ -578,7 +596,7 @@
     {
      "data": {
       "text/plain": [
-       "'https://harmony.earthdata.nasa.gov/jobs/dfefc536-768c-4db3-a7d2-c326e9253042'"
+       "'https://harmony.earthdata.nasa.gov/jobs/89d0a34f-d9bd-466e-bd7b-f93891956b7b'"
       ]
      },
      "execution_count": 15,
@@ -607,18 +625,26 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "# Job status is running. Progress is 0. Trying again.\n",
+      "# Job status is running. Progress is 0. Trying again.\n",
+      "# Job status is running. Progress is 0. Trying again.\n",
+      "# Job status is running. Progress is 0. Trying again.\n",
+      "# Job status is running. Progress is 0. Trying again.\n",
+      "# Job status is running. Progress is 0. Trying again.\n",
+      "# Job status is running. Progress is 0. Trying again.\n",
+      "# Job status is running. Progress is 100. Trying again.\n",
       "# Job progress is 100%. Links to job outputs are displayed below:\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "['https://harmony.earthdata.nasa.gov/jobs/dfefc536-768c-4db3-a7d2-c326e9253042',\n",
-       " 'https://harmony.earthdata.nasa.gov/stac/dfefc536-768c-4db3-a7d2-c326e9253042/',\n",
+       "['https://harmony.earthdata.nasa.gov/jobs/89d0a34f-d9bd-466e-bd7b-f93891956b7b',\n",
+       " 'https://harmony.earthdata.nasa.gov/stac/89d0a34f-d9bd-466e-bd7b-f93891956b7b/',\n",
        " 'https://harmony.earthdata.nasa.gov/cloud-access.sh',\n",
        " 'https://harmony.earthdata.nasa.gov/cloud-access',\n",
-       " 's3://harmony-prod-staging/public/harmony/netcdf-to-zarr/5eac3d26-430c-4bb5-b131-98e08f4e65e1/',\n",
-       " 's3://harmony-prod-staging/public/harmony/netcdf-to-zarr/5eac3d26-430c-4bb5-b131-98e08f4e65e1/GRCTellus.JPL.200204_202009.GLO.RL06M.MSCNv02CRI.zarr']"
+       " 's3://harmony-prod-staging/public/harmony/netcdf-to-zarr/bf4442a2-67d3-427a-b1b6-0d34da49afea/',\n",
+       " 's3://harmony-prod-staging/public/harmony/netcdf-to-zarr/bf4442a2-67d3-427a-b1b6-0d34da49afea/GRCTellus.JPL.200204_202009.GLO.RL06M.MSCNv02CRI.zarr']"
       ]
      },
      "metadata": {},
@@ -661,7 +687,7 @@
     {
      "data": {
       "text/plain": [
-       "'s3://harmony-prod-staging/public/harmony/netcdf-to-zarr/5eac3d26-430c-4bb5-b131-98e08f4e65e1/GRCTellus.JPL.200204_202009.GLO.RL06M.MSCNv02CRI.zarr'"
+       "'s3://harmony-prod-staging/public/harmony/netcdf-to-zarr/bf4442a2-67d3-427a-b1b6-0d34da49afea/GRCTellus.JPL.200204_202009.GLO.RL06M.MSCNv02CRI.zarr'"
       ]
      },
      "execution_count": 17,
@@ -693,7 +719,7 @@
     {
      "data": {
       "text/plain": [
-       "'2020-12-02T02:19:19.000Z'"
+       "'2020-12-03T06:24:39.000Z'"
       ]
      },
      "execution_count": 18,
@@ -1010,7 +1036,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.colorbar.Colorbar at 0x7f573e327fa0>"
+       "<matplotlib.colorbar.Colorbar at 0x7f8dd6129280>"
       ]
      },
      "execution_count": 25,
@@ -3690,7 +3716,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.3"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
I deleted the stored outputs from the authentication cells at the top of the notebook, and changed a default value in a cell that conditionally submits a new Harmony request to zarr reformatter service if the value is None. That''s the behavior that we want. Before it stored a string with my most recent jobId by default, and that job si not accessible to other users.