### PR TITLE
fix tutorial_cmr.py companion script for tutorial2; include HTTPError…

### DIFF
--- a/Part-II/02_arctic_insitu_pts/tutorial_cmr.py
+++ b/Part-II/02_arctic_insitu_pts/tutorial_cmr.py
@@ -5,7 +5,7 @@ import itertools
 import netrc
 import getpass
 from urllib.parse import urlparse
-
+from urllib.request import HTTPError
 from shapely.geometry import Polygon
 import pandas as pd
 import geopandas


### PR DESCRIPTION
Fix the HTTPError problem when tutorial_cmr.py function called in demo notebook for tutorial 2. Just needed import statement i think. will test in binderhub and comment here if required